### PR TITLE
Fix #4019: exception treatment for NoneType group attribute.

### DIFF
--- a/sphinx/ext/inheritance_diagram.py
+++ b/sphinx/ext/inheritance_diagram.py
@@ -80,14 +80,18 @@ def try_import(objname):
         __import__(objname)
         return sys.modules.get(objname)  # type: ignore
     except ImportError:
-        modname, attrname = module_sig_re.match(objname).groups()  # type: ignore
-        if modname is None:
-            return None
         try:
-            __import__(modname)
-            return getattr(sys.modules.get(modname), attrname, None)
-        except ImportError:
+            modname, attrname = module_sig_re.match(objname).groups()  # type: ignore
+        except AttributeError:
             return None
+        else:
+            if modname is None:
+                return None
+            try:
+                __import__(modname)
+                return getattr(sys.modules.get(modname), attrname, None)
+            except ImportError:
+                return None
 
 
 def import_classes(name, currmodule):


### PR DESCRIPTION
Subject: AttributeError exception is stopping make process

### Feature or Bugfix
- Bugfix

### Purpose
- This should not stop make process, after all, the warning about missing module is still showed. 

### Detail
- Insert treatment for attribute error when trying to get group attribute from a None object. It is caused by a not found module name inserted in inheritance diagram.

### Relates
- #4019 


